### PR TITLE
tv sends lowercase type, fixed

### DIFF
--- a/docs/send_signals_from_trading_view_to_ptn.md
+++ b/docs/send_signals_from_trading_view_to_ptn.md
@@ -75,3 +75,18 @@ in setting up your alert.
 
 <img width="600" alt="Screenshot 2024-03-19 at 6 02 24 PM" src="https://github.com/taoshidev/proprietary-trading-network/assets/68529441/1b6a0198-a875-4881-a7d7-2056d3e02ac2">
 <img width="600" alt="Screenshot 2024-03-19 at 1 26 40 PM" src="https://github.com/taoshidev/proprietary-trading-network/assets/68529441/22cfa76f-7a8f-4db9-a9eb-ca5630c39f61">
+
+
+Note:
+You will want to silo access to your new PTN signals server on port 80 so that only TradingView can access it.
+
+See here for the latest <a href="https://www.tradingview.com/support/solutions/43000529348-about-webhooks/">IPv4 TradingView addresses</a>.
+
+At the time of writing, they can be whitelisted like this for example:
+
+```bash
+sudo ufw allow from 52.89.214.238 to any port 80;
+sudo ufw allow from 34.212.75.30 to any port 80;
+sudo ufw allow from 54.218.53.128 to any port 80;
+sudo ufw allow from 52.32.178.7 to any port 80;
+```

--- a/mining/run_receive_signals_server.py
+++ b/mining/run_receive_signals_server.py
@@ -62,7 +62,7 @@ def handle_data():
 
         signal = Signal(trade_pair=TradePair.from_trade_pair_id(signal_trade_pair_str),
                         leverage=float(data["leverage"]),
-                        order_type=OrderType.from_string(data["order_type"]))
+                        order_type=OrderType.from_string(data["order_type"].upper()))
         # make miner received signals dir if doesnt exist
         ValiBkpUtils.make_dir(MinerConfig.get_miner_received_signals_dir())
         # store miner signal


### PR DESCRIPTION
TradingView sends lowercase types like "long", "short", or "flat".

However, the OrderType object for the PTN is case sensitive and maps to uppercase values.

# bad (example)
```bash
~# curl -X POST -H "Content-Type: application/json" -d '{"api_key": "somekey", "order_type": "long", "trade_pair": "BTCUSD", "leverage": "0.0705"}' http://127.0.0.1:80/api/receive-signal
{"error":"improperly formatted signal received. No matching order type found for value 'long'. Please check the input and try again."}
```

# good
```bash
~# curl -X POST -H "Content-Type: application/json" -d '{"api_key": "somekey", "order_type": "LONG", "trade_pair": "BTCUSD", "leverage": "0.0705"}' http://127.0.0.1:80/api/receive-signal
{"message":"Signal {'trade_pair': \"{'trade_pair_id': 'BTCUSD', 'trade_pair': 'BTC/USD', 'fees': 0.001, 'min_leverage': 0.001, 'max_leverage': 20, 'trade_pair_category': <TradePairCategory.CRYPTO: 'crypto'>}\", 'order_type': 'LONG', 'leverage': 0.0705} received successfully"}
```

