### PR TITLE
Only trusted validators allowed to send checkpoints

### DIFF
--- a/miner_config.py
+++ b/miner_config.py
@@ -3,6 +3,7 @@ from vali_config import ValiConfig
 
 class MinerConfig:
     HIGH_V_TRUST_THRESHOLD = 0.75
+    STAKE_MIN = 1000.0
 
     @staticmethod
     def get_miner_received_signals_dir() -> str:

--- a/miner_config.py
+++ b/miner_config.py
@@ -4,6 +4,7 @@ from vali_config import ValiConfig
 class MinerConfig:
     HIGH_V_TRUST_THRESHOLD = 0.75
     STAKE_MIN = 1000.0
+    AXON_NO_IP = "0.0.0.0"
 
     @staticmethod
     def get_miner_received_signals_dir() -> str:

--- a/miner_objects/prop_net_order_placer.py
+++ b/miner_objects/prop_net_order_placer.py
@@ -68,7 +68,11 @@ class PropNetOrderPlacer:
         Manages retry attempts and employs exponential backoff for failed attempts.
         """
         hotkey_to_v_trust = {neuron.hotkey: neuron.validator_trust for neuron in self.metagraph.neurons}
-        axons_to_try = self.metagraph.axons
+        # TODO: combine testnet and mainnet cases
+        if not self.is_testnet:
+            axons_to_try = [n.axon_info for n in self.metagraph.neurons if n.stake > bt.Balance(MinerConfig.STAKE_MIN)]
+        else:
+            axons_to_try = self.metagraph.axons
         axons_to_try.sort(key=lambda validator: hotkey_to_v_trust[validator.hotkey], reverse=True)
 
         validator_hotkey_to_axon = {}

--- a/miner_objects/prop_net_order_placer.py
+++ b/miner_objects/prop_net_order_placer.py
@@ -70,7 +70,9 @@ class PropNetOrderPlacer:
         hotkey_to_v_trust = {neuron.hotkey: neuron.validator_trust for neuron in self.metagraph.neurons}
         # TODO: combine testnet and mainnet cases
         if not self.is_testnet:
-            axons_to_try = [n.axon_info for n in self.metagraph.neurons if n.stake > bt.Balance(MinerConfig.STAKE_MIN)]
+            axons_to_try = [n.axon_info for n in self.metagraph.neurons
+                            if n.stake > bt.Balance(MinerConfig.STAKE_MIN)
+                            and n.axon_info.ip != MinerConfig.AXON_NO_IP]
         else:
             axons_to_try = self.metagraph.axons
         axons_to_try.sort(key=lambda validator: hotkey_to_v_trust[validator.hotkey], reverse=True)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -171,7 +171,8 @@ class Validator:
                                               signal_sync_condition=self.signal_sync_condition,
                                               n_orders_being_processed=self.n_orders_being_processed)
         self.p2p_syncer = P2PSyncer(wallet=self.wallet,
-                                    metagraph=self.metagraph)
+                                    metagraph=self.metagraph,
+                                    is_testnet=not self.is_mainnet)
         # keep track of values for checkpoint sync
         self.num_trusted_validators = len(self.p2p_syncer.get_trusted_validators())
         self.received_checkpoints = 0
@@ -683,8 +684,7 @@ class Validator:
         sender_hotkey = synapse.dendrite.hotkey
 
         # only want to process and read checkpoints from trusted validators
-        # TODO: remove mainnet check
-        if not self.is_mainnet or sender_hotkey in [axon.hotkey for axon in self.p2p_syncer.get_trusted_validators()]:
+        if sender_hotkey in [axon.hotkey for axon in self.p2p_syncer.get_trusted_validators()]:
             synapse.validator_receive_hotkey = self.wallet.hotkey.ss58_address
 
             #TODO: count received checkpoints, reset received after every completed sync
@@ -724,33 +724,6 @@ class Validator:
             synapse.error_message = "Rejecting checkpoint from non-trusted validator"
             synapse.successfully_processed = False
         return synapse
-
-    # temp test method to print out the metagraph state
-    def print_metagraph_attributes(self):
-        # for n in self.metagraph.neurons:
-        #     n.validator_trust = random.random()
-        #     n.stake = random.randrange(1500)
-
-        table = [[n.axon_info.hotkey[:4] for n in self.metagraph.neurons],
-                 [n.axon_info.ip for n in self.metagraph.neurons], [str(n.stake)[:7] for n in self.metagraph.neurons],
-                 [n.validator_trust for n in self.metagraph.neurons]]
-        # my_uid = self.metagraph.hotkeys.index(self.wallet.hotkey.ss58_address)
-        # bt.logging.info(f"my uid {my_uid}")
-        smalltable = [r[:20] for r in table]
-        print(tabulate(smalltable, tablefmt="simple_grid"))
-        smalltable = [r[20:40] for r in table]
-        print(tabulate(smalltable, tablefmt="simple_grid"))
-        smalltable = [r[40:60] for r in table]
-        print(tabulate(smalltable, tablefmt="simple_grid"))
-        smalltable = [r[60:80] for r in table]
-        print(tabulate(smalltable, tablefmt="simple_grid"))
-        smalltable = [r[80:100] for r in table]
-        print(tabulate(smalltable, tablefmt="simple_grid"))
-        # bt.logging.info(f"stake {[n.stake for n in self.metagraph.neurons]}")
-
-        print(self.num_trusted_validators, " trusted validators___________")
-        for a in self.p2p_syncer.get_trusted_validators():
-            print(a.hotkey)
 
 # This is the main function, which runs the miner.
 if __name__ == "__main__":

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -11,8 +11,6 @@ import uuid
 from typing import Tuple
 from enum import Enum
 
-from tabulate import tabulate
-
 import template
 import argparse
 import traceback

--- a/vali_config.py
+++ b/vali_config.py
@@ -274,3 +274,9 @@ class ValiConfig:
     MAX_MINER_PLAGIARISM_SCORE = 0.9 # want to make sure we're filtering out the bad actors
     TOP_MINER_BENEFIT = 0.90
     TOP_MINER_PERCENT = 0.40
+
+    ## Qualifications to be a trusted validator sending checkpoints
+    TOP_N = 10
+    V_TRUST_THRESHOLD = 0.9
+    STAKE_MIN = 1000.0
+    V_TRUST_MIN = 0.5

--- a/vali_config.py
+++ b/vali_config.py
@@ -277,6 +277,5 @@ class ValiConfig:
 
     ## Qualifications to be a trusted validator sending checkpoints
     TOP_N = 10
-    V_TRUST_THRESHOLD = 0.9
     STAKE_MIN = 1000.0
-    V_TRUST_MIN = 0.5
+    AXON_NO_IP = "0.0.0.0"

--- a/vali_objects/utils/p2p_syncer.py
+++ b/vali_objects/utils/p2p_syncer.py
@@ -104,7 +104,8 @@ class P2PSyncer:
         """
         # TODO: remove testnet flag
         if self.is_testnet:
-            return [a for a in self.metagraph.axons if a.ip != ValiConfig.AXON_NO_IP]
+            return self.metagraph.axons
+            # return [a for a in self.metagraph.axons if a.ip != ValiConfig.AXON_NO_IP]
         if neurons is None:
             neurons = self.metagraph.neurons
         validator_axons = [n.axon_info for n in neurons

--- a/vali_objects/utils/p2p_syncer.py
+++ b/vali_objects/utils/p2p_syncer.py
@@ -9,6 +9,7 @@ import bittensor as bt
 import template
 from runnable.generate_request_core import generate_request_core
 from time_util.time_util import TimeUtil
+from vali_config import ValiConfig
 from vali_objects.decoders.generalized_json_decoder import GeneralizedJSONDecoder
 from vali_objects.position import Position
 from vali_objects.utils.auto_sync import AUTO_SYNC_ORDER_LAG_MS
@@ -21,11 +22,21 @@ class P2PSyncer:
         self.metagraph = metagraph
         self.last_signal_sync_time_ms = 0
         self.received_checkpoints = 0
+        self.hotkey = self.wallet.hotkey.ss58_address
+
+        # TODO: temp flag for testnet
+        self.testnet = True
 
     async def send_checkpoint(self):
         """
         serializes checkpoint json and transmits to all validators via synapse
         """
+        # only trusted validators should send checkpoints
+        # TODO: remove testnet flag
+        if not self.testnet and self.hotkey not in [axon.hotkey for axon in self.get_trusted_validators()]:
+            bt.logging.info("Aborting send_checkpoint; not a top trusted validator")
+            return
+
         # get our current checkpoint
         now_ms = TimeUtil.now_in_millis()
         checkpoint_dict = generate_request_core(time_now=now_ms)
@@ -60,28 +71,62 @@ class P2PSyncer:
 
         # get axons to send checkpoints to
         dendrite = bt.dendrite(wallet=self.wallet)
-        validator_axons = self.metagraph.axons
+        validator_axons = self.get_validators()
 
-        if len(validator_axons) == 0:
-            bt.logging.info(f"no valid validators found. skipping sending checkpoint")
-        else:
+        try:
             # create dendrite and transmit synapse
             checkpoint_synapse = template.protocol.ValidatorCheckpoint(checkpoint=encoded_checkpoint)
             validator_responses = await dendrite.forward(axons=validator_axons, synapse=checkpoint_synapse)
 
-            bt.logging.info(f"sending checkpoint from validator {self.wallet.hotkey.ss58_address}")
+            bt.logging.info(f"Sending checkpoint from validator {self.wallet.hotkey.ss58_address}")
 
             successes = 0
             failures = 0
             for response in validator_responses:
                 if response.successfully_processed:
-                    print(f"successfully processed ack from {response.validator_receive_hotkey}")
+                    bt.logging.info(f"Successfully processed ack from {response.validator_receive_hotkey}")
                     successes += 1
                 else:
                     failures += 1
 
             bt.logging.info(f"{successes} responses succeeded")
             bt.logging.info(f"{failures} responses failed")
+        except Exception as e:
+            bt.logging.info(f"Error sending checkpoint with error [{e}]")
+
+    def get_validators(self):
+        """
+        get a list of all validators. defined as:
+        stake > 1000 and validator_trust > 0.5
+        """
+        # TODO: remove testnet flag
+        if self.testnet:
+            return self.metagraph.axons
+        neurons = self.metagraph.neurons
+        validator_neurons = [n for n in neurons if n.stake > bt.Balance(ValiConfig.STAKE_MIN)
+                             and n.validator_trust > ValiConfig.V_TRUST_MIN]
+
+        return [n.axon_info for n in validator_neurons if n.axon_info.ip != "0.0.0.0"]
+
+    def get_trusted_validators(self):
+        """
+        get a list of the trusted validators for checkpoint sending. defined as:
+        top 10 by stake OR validator_trust > 0.9
+        """
+        # TODO: filter min stake as well?
+        neurons = self.metagraph.neurons
+        # only validators with top 10 stake, or v_trust > 0.9 should send checkpoints
+        top_stake_neurons = sorted(neurons, key=lambda n: n.stake, reverse=True)
+        top_stake_axons = [n.axon_info for n in top_stake_neurons if n.stake > bt.Balance(ValiConfig.STAKE_MIN)
+                           and n.axon_info.ip != "0.0.0.0"][:ValiConfig.TOP_N]
+        high_v_trust_axons = [n.axon_info for n in neurons if n.validator_trust > ValiConfig.V_TRUST_THRESHOLD]
+
+        # axons could contain duplicates, create set based on axon hotkeys and then filter axons
+        axons = top_stake_axons + high_v_trust_axons
+        trusted_hotkeys = set(a.hotkey for a in axons)
+        trusted_axons = [a for a in axons if a.hotkey in trusted_hotkeys and a.ip != "0.0.0.0"]
+
+        return trusted_axons
 
     def sync_positions_with_cooldown(self, auto_sync_enabled:bool, run_more:bool):
         # Check if the time is right to sync signals
@@ -103,7 +148,7 @@ class P2PSyncer:
             bt.logging.info("calling send_checkpoint")
             asyncio.run(self.send_checkpoint())
         except Exception as e:
-            bt.logging.error(f"Error syncing positions: {e}")
+            bt.logging.error(f"Error sending checkpoint: {e}")
             bt.logging.error(traceback.format_exc())
 
         self.last_signal_sync_time_ms = TimeUtil.now_in_millis()


### PR DESCRIPTION
## Taoshi Pull Request

### Description
Add checks so that miners only send orders to other validators. Validators only send checkpoints if they are a trusted validator. Validators will only send checkpoints to other validators. Validators will only unpack received checkpoints if they have been sent by a trusted validator.

Added a method to print out metagraph state.
testnet bypasses the get_validators and get_trusted_validators because metagraph attributes including stake are not set.

### Related Issues (JIRA)
https://sataoshi.atlassian.net/jira/software/c/projects/TE/boards/2?selectedIssue=TE-309

### Checklist
- [ ] I have tested my changes on testnet.
- [ ] I have updated any necessary documentation.
- [ ] I have added unit tests for my changes (if applicable).
- [ ] If there are breaking changes for validators, I have (or will) notify the community in Discord of the release.

### Reviewer Instructions
[Provide any specific instructions or areas you would like the reviewer to focus on.]

### Definition of Done
- [ ] Code has been reviewed.
- [ ] All checks and tests pass.
- [ ] Documentation is up to date.
- [ ] Approved by at least one reviewer.

### Checklist (for the reviewer)
- [ ] Code follows project conventions.
- [ ] Code is well-documented.
- [ ] Changes are necessary and align with the project's goals.
- [ ] No breaking changes introduced.

### Optional: Deploy Notes
[Any instructions or notes related to deployment, if applicable.]

/cc @mention_reviewer
