### PR TITLE
Perf Ledger optimization + TwelveData Service Outage hotfix

### DIFF
--- a/data_generator/twelvedata_service.py
+++ b/data_generator/twelvedata_service.py
@@ -37,7 +37,10 @@ class TwelveDataService(BaseDataService):
         if disable_ws:
             self._heartbeat_thread = None
         else:
-            self._reset_websocket()
+            try:
+                self._reset_websocket()
+            except Exception as e:
+                bt.logging.error(f"Failed to initialize TD websocket on initial call: {e}. Will continue trying in _websocket_heartbeat")
             self._heartbeat_thread = threading.Thread(target=self._websocket_heartbeat)
             self._heartbeat_thread.daemon = True
             self._heartbeat_thread.start()

--- a/meta/meta.json
+++ b/meta/meta.json
@@ -1,3 +1,3 @@
 {
-  "subnet_version": "3.4.0"
+  "subnet_version": "3.4.1"
 }

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -177,8 +177,7 @@ class Validator:
         self.last_checkpoint_time = 0
         self.timestamp_manager = TimestampManager(config=self.config, metagraph=self.metagraph, hotkey=self.wallet.hotkey.ss58_address)
 
-        self.perf_ledger_manager = PerfLedgerManager(self.metagraph, live_price_fetcher=self.live_price_fetcher,
-                                                     shutdown_dict=shutdown_dict, position_syncer=self.position_syncer)
+        self.perf_ledger_manager = PerfLedgerManager(self.metagraph, shutdown_dict=shutdown_dict, position_syncer=self.position_syncer)
         # Start the perf ledger updater loop in its own thread
         self.perf_ledger_updater_thread = threading.Thread(target=self.perf_ledger_manager.run_update_loop, daemon=True)
         self.perf_ledger_updater_thread.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ polygon-api-client == 1.13.7
 scikit-learn == 1.5.0
 scipy == 1.12.0
 pandas == 2.2.2
-twelvedata == 1.2.12
+twelvedata == 1.2.20
 flask == 3.0.3
 waitress == 2.1.2
 matplotlib == 3.9.0

--- a/vali_objects/utils/live_price_fetcher.py
+++ b/vali_objects/utils/live_price_fetcher.py
@@ -20,7 +20,7 @@ from statistics import median
 class LivePriceFetcher():
     def __init__(self, secrets, disable_ws=False):
         if "twelvedata_apikey" in secrets:
-            self.twelve_data_service = TwelveDataService(api_key=secrets["twelvedata_apikey"], disable_ws=disable_ws)
+            self.twelve_data_service = TwelveDataService(api_key=secrets["twelvedata_apikey"], disable_ws=True)
         else:
             raise Exception("TwelveData API key not found in secrets.json")
         if "polygon_apikey" in secrets:

--- a/vali_objects/vali_dataclasses/perf_ledger.py
+++ b/vali_objects/vali_dataclasses/perf_ledger.py
@@ -1033,6 +1033,6 @@ if __name__ == "__main__":
     all_hotkeys_on_disk = CacheController.get_directory_names(all_miners_dir)
     mmg = MockMetagraph(hotkeys=all_hotkeys_on_disk)
     perf_ledger_manager = PerfLedgerManager(metagraph=mmg, running_unit_tests=False)
-    #perf_ledger_manager.update(testing_one_hotkey='5EUTaAo7vCGxvLDWRXRrEuqctPjt9fKZmgkaeFZocWECUe9X')
-    perf_ledger_manager.update(regenerate_all_ledgers=True)
+    perf_ledger_manager.update(testing_one_hotkey='5Cqqc5mVr82A2ZH6XqcrgkqbVUR6UwuktRJXaBGLicF9BjFP')
+    #perf_ledger_manager.update(regenerate_all_ledgers=True)
 


### PR DESCRIPTION
Perf Ledger optimization:
The current indices market open/close logic is overcomplicated. This brings it in line with the forex logic and adds the same cacheing. Huge speedups for traders that have long running SPX positions.

TwelveData Service Outage hotfix:
Adjust perf ledger code so that it is not dependent on TD being up.
Disable TD for now while figuring out how to suppress the 1s interval spam messages during an outage.