### PR TITLE
Prune order from positions

### DIFF
--- a/meta/meta.json
+++ b/meta/meta.json
@@ -1,3 +1,3 @@
 {
-  "subnet_version": "3.4.3"
+  "subnet_version": "3.4.4"
 }

--- a/vali_objects/utils/p2p_syncer.py
+++ b/vali_objects/utils/p2p_syncer.py
@@ -226,8 +226,9 @@ class P2PSyncer(ValidatorSyncBase):
                             bt.logging.info(
                                 f"Order {order_uuid} with Position {position_uuid} only appeared [{order_counts[position_uuid][order_uuid]}/{position_counts[position_uuid]}] times on miner {position['miner_hotkey']}. Skipping")
 
-                # TODO: make sure first order is not leverage 0
                 new_position.orders.sort(key=lambda o: o.processed_ms)
+                if len(new_position.orders) > 0 and new_position.orders[0].leverage == 0:
+                    bt.logging.info(f"Miner[{new_position.miner_hotkey}] Position [{new_position.position_uuid}] with orders {[o.order_uuid for o in new_position.orders]} first order leverage is 0")
                 new_position.rebuild_position_with_updated_orders()
                 position_dict = json.loads(new_position.to_json_string())
                 uuid_matched_positions.append(position_dict)


### PR DESCRIPTION
## Taoshi Pull Request

### Description
- An order can appear in multiple positions across all validators. We only keep the order under the position that it appears the most in, and remove the order from all other positions.
- Logging for positions if the first order leverage is zero.

### Related Issues (JIRA)
[Reference any related issues or tasks that this pull request addresses or closes.]

### Checklist
- [ ] I have tested my changes on testnet.
- [ ] I have updated any necessary documentation.
- [ ] I have added unit tests for my changes (if applicable).
- [ ] If there are breaking changes for validators, I have (or will) notify the community in Discord of the release.

### Reviewer Instructions
[Provide any specific instructions or areas you would like the reviewer to focus on.]

### Definition of Done
- [ ] Code has been reviewed.
- [ ] All checks and tests pass.
- [ ] Documentation is up to date.
- [ ] Approved by at least one reviewer.

### Checklist (for the reviewer)
- [ ] Code follows project conventions.
- [ ] Code is well-documented.
- [ ] Changes are necessary and align with the project's goals.
- [ ] No breaking changes introduced.

### Optional: Deploy Notes
[Any instructions or notes related to deployment, if applicable.]

/cc @mention_reviewer
