### PR TITLE
Websocket refactor and per-websocket reset logic

### DIFF
--- a/meta/meta.json
+++ b/meta/meta.json
@@ -1,3 +1,3 @@
 {
-  "subnet_version": "4.7.11"
+  "subnet_version": "4.7.12"
 }


### PR DESCRIPTION
working on RT21CHK


The motivation here is that the Polygon crypto websocket stream on RT21 failed but the current logic doesn't reset individual streams. It resets all 3 and does so by checking events across all streams (stocks, forex, crypto). This PR checks events per stream and resets appropriately. 