### PR TITLE
Retroactively update challenge period start times

### DIFF
--- a/meta/meta.json
+++ b/meta/meta.json
@@ -1,3 +1,3 @@
 {
-  "subnet_version": "5.1.10"
+  "subnet_version": "5.1.11"
 }

--- a/shared_objects/cache_controller.py
+++ b/shared_objects/cache_controller.py
@@ -62,7 +62,8 @@ class CacheController:
 
     def refresh_allowed(self, refresh_interval_ms):
         self.attempted_start_time_ms = TimeUtil.now_in_millis()
-        return self.attempted_start_time_ms - self.get_last_update_time_ms() > refresh_interval_ms
+        return self.running_unit_tests or \
+                    self.attempted_start_time_ms - self.get_last_update_time_ms() > refresh_interval_ms
 
     def init_cache_files(self) -> None:
         ValiBkpUtils.make_dir(ValiBkpUtils.get_vali_dir(running_unit_tests=self.running_unit_tests))

--- a/tests/vali_tests/test_challengeperiod_integration.py
+++ b/tests/vali_tests/test_challengeperiod_integration.py
@@ -288,9 +288,9 @@ class TestChallengePeriodIntegration(TestBase):
         self.assertEqual(ledgers.get(self.DEFAULT_MINER_HOTKEY, len(PerfLedger().cps)), 0)
 
         # Check the failing criteria initially
-        l = ledgers.get(self.DEFAULT_MINER_HOTKEY)
+        ledger = ledgers.get(self.DEFAULT_MINER_HOTKEY)
         failing_criteria, _ = self.challengeperiod_manager.screen_failing_criteria(
-            ledger_element=l[TP_ID_PORTFOLIO] if l else None
+            ledger_element=ledger[TP_ID_PORTFOLIO] if ledger else None
         )
 
         self.assertFalse(failing_criteria)

--- a/tests/vali_tests/test_challengeperiod_integration.py
+++ b/tests/vali_tests/test_challengeperiod_integration.py
@@ -173,7 +173,7 @@ class TestChallengePeriodIntegration(TestBase):
         self.challengeperiod_manager._add_challengeperiod_testing_in_memory_and_disk(
             self.MINER_NAMES,
             eliminations=[],
-            current_time=self.START_TIME
+            hk_to_first_order_time=self.HK_TO_OPEN_MS
         )
 
     def tearDown(self):
@@ -242,7 +242,7 @@ class TestChallengePeriodIntegration(TestBase):
         self.challengeperiod_manager._add_challengeperiod_testing_in_memory_and_disk(
             new_hotkeys=self.challengeperiod_manager.metagraph.hotkeys,
             eliminations=self.challengeperiod_manager.elimination_manager.get_eliminations_from_memory(),
-            current_time=self.max_open_ms
+            hk_to_first_order_time=self.HK_TO_OPEN_MS
         )
 
         self.assertEqual(len(self.challengeperiod_manager.challengeperiod_testing), len(self.NOT_MAIN_COMP_MINER_NAMES))
@@ -415,7 +415,7 @@ class TestChallengePeriodIntegration(TestBase):
         self.challengeperiod_manager._add_challengeperiod_testing_in_memory_and_disk(
             new_hotkeys=self.MINER_NAMES,
             eliminations=[],
-            current_time=self.max_open_ms
+            hk_to_first_order_time=self.HK_TO_OPEN_MS
         )
 
         testing_set = set(self.challengeperiod_manager.challengeperiod_testing.keys())
@@ -436,7 +436,7 @@ class TestChallengePeriodIntegration(TestBase):
         self.challengeperiod_manager._add_challengeperiod_testing_in_memory_and_disk(
             new_hotkeys=new_miners,
             eliminations=[],
-            current_time=self.max_open_ms
+            hk_to_first_order_time=self.HK_TO_OPEN_MS
         )
 
         self.assertTrue(len(self.challengeperiod_manager.challengeperiod_testing) == 0)
@@ -447,7 +447,7 @@ class TestChallengePeriodIntegration(TestBase):
         self.challengeperiod_manager._add_challengeperiod_testing_in_memory_and_disk(
             new_hotkeys=new_miners,
             eliminations=[],
-            current_time=self.max_open_ms
+            hk_to_first_order_time=self.HK_TO_OPEN_MS
         )
 
         self.assertTrue(len(self.challengeperiod_manager.challengeperiod_testing) == 0)
@@ -463,7 +463,7 @@ class TestChallengePeriodIntegration(TestBase):
         self.challengeperiod_manager._add_challengeperiod_testing_in_memory_and_disk(
             new_hotkeys=self.MINER_NAMES,
             eliminations=[],
-            current_time=self.max_open_ms
+            hk_to_first_order_time=self.HK_TO_OPEN_MS
         )
 
         # All the miners should be passed to testing now

--- a/vali_objects/utils/challengeperiod_manager.py
+++ b/vali_objects/utils/challengeperiod_manager.py
@@ -71,19 +71,19 @@ class ChallengePeriodManager(CacheController):
         if any_changes:
             self._write_challengeperiod_from_memory_to_disk()
 
-    def _refresh_challengeperiod_start_time(self, hk_to_first_order_time: dict[str, int]):
+    def _refresh_challengeperiod_start_time(self, hk_to_first_order_time_ms: dict[str, int]):
         """
         retroactively update the challengeperiod_testing start time based on time of first order.
         used when a miner is un-eliminated, and positions are preserved.
         """
         bt.logging.info("Refreshing challengeperiod start times")
         any_changes = False
-        for hotkey, start_time in self.challengeperiod_testing.items():
-            first_order_time = hk_to_first_order_time[hotkey]
-            if start_time != first_order_time:
-                bt.logging.info(f"Challengeperiod start time for {hotkey} updated from: {datetime.utcfromtimestamp(start_time)} "
-                                f"to: {datetime.utcfromtimestamp(first_order_time)}, {(start_time-first_order_time)/1000}s delta")
-                self.challengeperiod_testing[hotkey] = first_order_time
+        for hotkey, start_time_ms in self.challengeperiod_testing.items():
+            first_order_time_ms = hk_to_first_order_time_ms[hotkey]
+            if start_time_ms != first_order_time_ms:
+                bt.logging.info(f"Challengeperiod start time for {hotkey} updated from: {datetime.utcfromtimestamp(start_time_ms/1000)} "
+                                f"to: {datetime.utcfromtimestamp(first_order_time_ms/1000)}, {(start_time_ms-first_order_time_ms)/1000}s delta")
+                self.challengeperiod_testing[hotkey] = first_order_time_ms
                 any_changes = True
         if any_changes:
             self._write_challengeperiod_from_memory_to_disk()

--- a/vali_objects/utils/challengeperiod_manager.py
+++ b/vali_objects/utils/challengeperiod_manager.py
@@ -70,7 +70,7 @@ class ChallengePeriodManager(CacheController):
                         if hotkey not in self.challengeperiod_success:
                             bt.logging.info(f"Adding hotkey {hotkey} to challengeperiod miners.")
                             any_changes = True
-                            self.challengeperiod_testing[hotkey] = hk_to_first_order_time[hotkey] if not self.running_unit_tests else current_time
+                            self.challengeperiod_testing[hotkey] = hk_to_first_order_time[hotkey]
         if any_changes:
             self._write_challengeperiod_from_memory_to_disk()
 

--- a/vali_objects/utils/challengeperiod_manager.py
+++ b/vali_objects/utils/challengeperiod_manager.py
@@ -104,7 +104,7 @@ class ChallengePeriodManager(CacheController):
 
         all_miners = challengeperiod_success_hotkeys + challengeperiod_testing_hotkeys
 
-        hk_to_positions, hk_to_first_order_time = self.position_manager.filtered_positions_for_scoring(hotkeys=all_miners)
+        hk_to_positions, hk_to_first_order_time = self.position_manager.filtered_positions_for_scoring(hotkeys=self.metagraph.hotkeys)
 
         # challenge period adds to testing if not in eliminated, already in the challenge period, or in the new eliminations list from disk
         self._add_challengeperiod_testing_in_memory_and_disk(

--- a/vali_objects/utils/challengeperiod_manager.py
+++ b/vali_objects/utils/challengeperiod_manager.py
@@ -87,8 +87,7 @@ class ChallengePeriodManager(CacheController):
                 any_changes = True
         if any_changes:
             self._write_challengeperiod_from_memory_to_disk()
-        else:
-            bt.logging.info("All challengeperiod start times up to date")
+        bt.logging.info("All challengeperiod start times up to date")
 
     def refresh(self, current_time: int = None):
         if not self.refresh_allowed(ValiConfig.CHALLENGE_PERIOD_REFRESH_TIME_MS):


### PR DESCRIPTION
## Taoshi Pull Request

### Description
Retroactively update the challenge period start time to be the time of oldest order, instead of current time.
Affects miners which have been un-eliminated, but whose positions were not wiped. This allowed them to erroneously re-enter challenge period with their existing positions and scores, but with a 90-day window beginning from the re-entry time.

### Related Issues (JIRA)
[Reference any related issues or tasks that this pull request addresses or closes.]

### Checklist
- [x] I have tested my changes on testnet.
- [ ] I have updated any necessary documentation.
- [x] I have added unit tests for my changes (if applicable).
- [ ] If there are breaking changes for validators, I have (or will) notify the community in Discord of the release.

### Reviewer Instructions
[Provide any specific instructions or areas you would like the reviewer to focus on.]

### Definition of Done
- [ ] Code has been reviewed.
- [ ] All checks and tests pass.
- [ ] Documentation is up to date.
- [ ] Approved by at least one reviewer.

### Checklist (for the reviewer)
- [ ] Code follows project conventions.
- [ ] Code is well-documented.
- [ ] Changes are necessary and align with the project's goals.
- [ ] No breaking changes introduced.

### Optional: Deploy Notes
[Any instructions or notes related to deployment, if applicable.]

/cc @mention_reviewer
