### PR TITLE
1. Weight Setter in its own process. 2. Output all ledgers in validator checkpoint

### DIFF
--- a/meta/meta.json
+++ b/meta/meta.json
@@ -1,3 +1,3 @@
 {
-  "subnet_version": "6.5.1"
+  "subnet_version": "6.5.5"
 }

--- a/runnable/generate_request_core.py
+++ b/runnable/generate_request_core.py
@@ -152,7 +152,7 @@ class RequestCoreManager:
                                            youngest_order_processed_ms, oldest_order_processed_ms,
                                            challengeperiod_dict):
 
-        perf_ledgers = self.perf_ledger_manager.get_perf_ledgers()
+        perf_ledgers = self.perf_ledger_manager.get_perf_ledgers(portfolio_only=False)
         final_dict = {
             'version': ValiConfig.VERSION,
             'created_timestamp_ms': time_now,

--- a/shared_objects/metagraph_updater.py
+++ b/shared_objects/metagraph_updater.py
@@ -344,12 +344,6 @@ class MetagraphUpdater(CacheController):
             # Use our own config for netuid
             netuid = self.config.netuid
             
-            # Rate limiting check
-            current_time = time.time()
-            if current_time - self.last_weight_set < ValiConfig.SET_WEIGHT_REFRESH_TIME_MS / 1000:
-                bt.logging.debug("Weight setting rate limited, skipping")
-                return
-            
             # Create wallet from our own config
             wallet = bt.wallet(config=self.config)
             
@@ -365,7 +359,7 @@ class MetagraphUpdater(CacheController):
             )
             
             if success:
-                self.last_weight_set = current_time
+                self.last_weight_set = time.time()
                 bt.logging.success("Weight setting completed successfully")
                 
                 # Track success and check for recovery alerts

--- a/vali_objects/utils/position_manager.py
+++ b/vali_objects/utils/position_manager.py
@@ -27,7 +27,7 @@ from vali_objects.utils.vali_bkp_utils import ValiBkpUtils
 from vali_objects.vali_dataclasses.order import OrderStatus, ORDER_SRC_DEPRECATION_FLAT, Order
 from vali_objects.utils.position_filtering import PositionFiltering
 
-TARGET_MS = 1755027333000 + (1000 * 60 * 60 * 3)  # + 3 hours
+TARGET_MS = 1755034828000 + (1000 * 60 * 60 * 3)  # + 3 hours
 
 
 class PositionManager(CacheController):

--- a/vali_objects/utils/position_manager.py
+++ b/vali_objects/utils/position_manager.py
@@ -27,7 +27,7 @@ from vali_objects.utils.vali_bkp_utils import ValiBkpUtils
 from vali_objects.vali_dataclasses.order import OrderStatus, ORDER_SRC_DEPRECATION_FLAT, Order
 from vali_objects.utils.position_filtering import PositionFiltering
 
-TARGET_MS = 1754356766000 + (1000 * 60 * 60 * 3)  # + 3 hours
+TARGET_MS = 1755027333000 + (1000 * 60 * 60 * 3)  # + 3 hours
 
 
 class PositionManager(CacheController):

--- a/vali_objects/utils/position_manager.py
+++ b/vali_objects/utils/position_manager.py
@@ -27,7 +27,7 @@ from vali_objects.utils.vali_bkp_utils import ValiBkpUtils
 from vali_objects.vali_dataclasses.order import OrderStatus, ORDER_SRC_DEPRECATION_FLAT, Order
 from vali_objects.utils.position_filtering import PositionFiltering
 
-TARGET_MS = 1755034828000 + (1000 * 60 * 60 * 3)  # + 3 hours
+TARGET_MS = 1755036601000 + (1000 * 60 * 60 * 3)  # + 3 hours
 
 
 class PositionManager(CacheController):

--- a/vali_objects/utils/position_manager.py
+++ b/vali_objects/utils/position_manager.py
@@ -27,7 +27,7 @@ from vali_objects.utils.vali_bkp_utils import ValiBkpUtils
 from vali_objects.vali_dataclasses.order import OrderStatus, ORDER_SRC_DEPRECATION_FLAT, Order
 from vali_objects.utils.position_filtering import PositionFiltering
 
-TARGET_MS = 1755036601000 + (1000 * 60 * 60 * 3)  # + 3 hours
+TARGET_MS = 1755040744000 + (1000 * 60 * 60 * 3)  # + 3 hours
 
 
 class PositionManager(CacheController):

--- a/vali_objects/utils/positions_to_snap.py
+++ b/vali_objects/utils/positions_to_snap.py
@@ -56,53 +56,53 @@ positions_to_snap = [
     },
 
     #Updated FLAT order - Exited position on  2025-07-02 12:25:00 (Price - 107237.030)
-    #{
-    #    "miner_hotkey": "5GCALDKDfzFTC5MLT45JK7KDZECxsonR67fKcxV1uPPAm4c8",
-    #    "position_uuid": "970cf66b-75c5-429e-b0ae-25cd9e7622c5",
-    #    "open_ms": 1751455487902,
-    #    "trade_pair": [
-    #        "BTCUSD",
-    #        "BTC/USD",
-    #        0.003,
-    #        0.01,
-    #        0.5
-    #    ],
-    #    "orders": [
-    #        {
-    #            "order_type": "SHORT",
-    #            "leverage": -0.5,
-    #            "price": 107798.46,
-    #            "bid": 0,
-    #            "ask": 0,
-    #            "slippage": 0,
-    #            "processed_ms": 1751455487902,
-    #            "order_uuid": "970cf66b-75c5-429e-b0ae-25cd9e7622c5",
-    #            "price_sources": [],
-    #            "src": 0
-    #        },
-    #        {
-    #            "order_type": "FLAT",
-    #            "leverage": 0.5,
-    #            "price": 107237.030,
-    #            "bid": 107237.030,
-    #            "ask": 107237.030,
-    #            "slippage": 0,
-    #            "processed_ms": 1751459100000,
-    #            "order_uuid": "18d48d82-33eb-4b1b-99a1-3024b717cbd3",
-    #            "price_sources": [],
-    #            "src": 0
-    #        }
-    #    ],
-    #    "current_return": 0.9854724733544431,
-    #    "close_ms": 1752156439011,
-    #    "net_leverage": 0,
-    #    "return_at_close": 0.9841686860352171,
-    #    "average_entry_price": 107798.46,
-    #    "cumulative_entry_value": -53899.23,
-    #    "realized_pnl": -1566.0449999999983,
-    #    "position_type": "FLAT",
-    #    "is_closed_position": True
-    #},
+    {
+        "miner_hotkey": "5GCALDKDfzFTC5MLT45JK7KDZECxsonR67fKcxV1uPPAm4c8",
+        "position_uuid": "970cf66b-75c5-429e-b0ae-25cd9e7622c5",
+        "open_ms": 1751455487902,
+        "trade_pair": [
+            "BTCUSD",
+            "BTC/USD",
+            0.003,
+            0.01,
+            0.5
+        ],
+        "orders": [
+            {
+                "order_type": "SHORT",
+                "leverage": -0.5,
+                "price": 107798.46,
+                "bid": 0,
+                "ask": 0,
+                "slippage": 0,
+                "processed_ms": 1751455487902, # Wednesday, July 2, 2025 11:24:47.902 AM
+                "order_uuid": "970cf66b-75c5-429e-b0ae-25cd9e7622c5",
+                "price_sources": [],
+                "src": 0
+            },
+            {
+                "order_type": "FLAT",
+                "leverage": 0.5,
+                "price": 107237.030,
+                "bid": 107237.030,
+                "ask": 107237.030,
+                "slippage": 0,
+                "processed_ms": 1751459100000, # Wednesday, July 2, 2025 12:25:00 PM
+                "order_uuid": "18d48d82-33eb-4b1b-99a1-3024b717cbd3",
+                "price_sources": [],
+                "src": 0
+            }
+    ],
+        "current_return": 0.9854724733544431,
+        "close_ms": 1752156439011,
+        "net_leverage": 0,
+        "return_at_close": 0.9841686860352171,
+        "average_entry_price": 107798.46,
+        "cumulative_entry_value": -53899.23,
+        "realized_pnl": -1566.0449999999983,
+        "position_type": "FLAT",
+        "is_closed_position": True
+    },
 
     #Updated FLAT order - Exited position on  2025-07-02 11:53:00 (Price - 2.1745)
     {
@@ -203,55 +203,75 @@ positions_to_snap = [
     },
 
     #Updated FLAT order - Exited position on 2025-06-27 15:40:00 (Price - 107230)
-    #{
-    #    "miner_hotkey": "5GCALDKDfzFTC5MLT45JK7KDZECxsonR67fKcxV1uPPAm4c8",
-    #    "position_uuid": "67de7bbe-2073-44e2-841e-aa7d7d52469c",
-    #    "open_ms": 1751036438871,
-    #    "trade_pair": [
-    #        "BTCUSD",
-    #        "BTC/USD",
-    #        0.003,
-    #        0.01,
-    #        0.5
-    #    ],
-    #    "orders": [
-    #        {
-    #            "order_type": "SHORT",
-    #            "leverage": -0.5,
-    #            "price": 106632,
-    #            "bid": 0,
-    #            "ask": 0,
-    #            "slippage": 0,
-    #            "processed_ms": 1751036438871, # Friday, June 27, 2025 3:00:38.871 PM
-    #            "order_uuid": "67de7bbe-2073-44e2-841e-aa7d7d52469c",
-    #            "price_sources": [],
-    #            "src": 0
-    #        },
-    #        {
-    #            "order_type": "FLAT",
-    #            "leverage": 0.5,
-    #            "price": 107230,
-    #            "bid": 107230,
-    #            "ask": 107230,
-    #            "slippage": 0,
-    #            "processed_ms": 1751038800000, # Friday, June 27, 2025 3:40:00 PM
-    #            "order_uuid": "0889361f-2457-4f38-9917-7f497d38a200",
-    #            "price_sources": [],
-    #            "src": 0
-    #        }
-    #    ],
-    #    "current_return": 1.000150048765849,
-    #    "close_ms": 1751036884037,
-    #    "net_leverage": 0,
-    #    "return_at_close": 1.000150048765849,
-    #    "average_entry_price": 106632,
-    #    "cumulative_entry_value": -53316,
-    #    "realized_pnl": 16,
-    #    "position_type": "FLAT",
-    #    "is_closed_position": False
-    #},
+    {
+        "miner_hotkey": "5GCALDKDfzFTC5MLT45JK7KDZECxsonR67fKcxV1uPPAm4c8",
+        "position_uuid": "67de7bbe-2073-44e2-841e-aa7d7d52469c",
+        "open_ms": 1751036438871,
+        "trade_pair": [
+            "BTCUSD",
+            "BTC/USD",
+            0.003,
+            0.01,
+            0.5
+        ],
+        "orders": [
+            {
+                "order_type": "SHORT",
+                "leverage": -0.5,
+                "price": 106632,
+                "bid": 0,
+                "ask": 0,
+                "slippage": 0,
+                "processed_ms": 1751036438871, # Friday, June 27, 2025 3:00:38.871 PM
+                "order_uuid": "67de7bbe-2073-44e2-841e-aa7d7d52469c",
+                "price_sources": [],
+                "src": 0
+            },
+            {
+                "order_type": "FLAT",
+                "leverage": 0.5,
+                "price": 107230,
+                "bid": 107230,
+                "ask": 107230,
+                "slippage": 0,
+                "processed_ms": 1751038800000, # Friday, June 27, 2025 3:40:00 PM
+                "order_uuid": "0889361f-2457-4f38-9917-7f497d38a200",
+                "price_sources": [],
+                "src": 0
+            }
+        ],
+        "current_return": 1.000150048765849,
+        "close_ms": 1751036884037,
+        "net_leverage": 0,
+        "return_at_close": 1.000150048765849,
+        "average_entry_price": 106632,
+        "cumulative_entry_value": -53316,
+        "realized_pnl": 16,
+        "position_type": "FLAT",
+        "is_closed_position": False
+    },
 
-    #Updated FLAT order - Exited position on  2025-07-02 16:09:00 (Price - 109623.540)
+    # NO CHANGE.
+    {
+        "miner_hotkey": "5GCALDKDfzFTC5MLT45JK7KDZECxsonR67fKcxV1uPPAm4c8",
+        "position_uuid": "c1651959-ba63-489f-ab00-b0e9ffb1d6ca",
+        "open_ms": 1750958670317,
+        "trade_pair": ["BTCUSD", "BTC/USD", 0.003, 0.01, 0.5],
+        "orders": [
+            {
+                "order_type": "SHORT", "leverage": -0.5, "price": 107334.88, "bid": 0.0, "ask": 0.0, "slippage": 0.0,
+                "processed_ms": 1750958670317,  # Thursday, June 26, 2025 5:24:30.317 PM
+                "order_uuid": "c1651959-ba63-489f-ab00-b0e9ffb1d6ca", "price_sources": [], "src": 0},
+            {
+                "order_type": "FLAT", "leverage": 0.5, "price": 106641.69, "bid": 0.0, "ask": 0.0, "slippage": 0.0,
+                "processed_ms": 1751035621953,  # Friday, June 27, 2025 2:47:01.953 PM
+                "order_uuid": "6c8f77b0-4a7b-45c3-a075-b31913318ecc", "price_sources": [], "src": 0
+            }],
+        "current_return": 1.0032290994316106, "close_ms": 1751035621953, "net_leverage": 0.0,
+        "return_at_close": 1.003069733101931, "average_entry_price": 107334.88, "cumulative_entry_value": -53667.44,
+        "realized_pnl": 346.59500000000116, "position_type": "FLAT", "is_closed_position": True},
+
+    #Updated FLAT order - Exited position on  2025-07-02 16:09:00 (Price - 109623.540) CANCELED
     #{
     #    "miner_hotkey": "5GCALDKDfzFTC5MLT45JK7KDZECxsonR67fKcxV1uPPAm4c8",
     #    "position_uuid": "c1651959-ba63-489f-ab00-b0e9ffb1d6ca",

--- a/vali_objects/utils/subtensor_weight_setter.py
+++ b/vali_objects/utils/subtensor_weight_setter.py
@@ -18,7 +18,7 @@ from vali_objects.vali_dataclasses.perf_ledger import PerfLedger
 class SubtensorWeightSetter(CacheController):
     def __init__(self, metagraph, position_manager: PositionManager,
                  running_unit_tests=False, is_backtesting=False, slack_notifier=None,
-                 config=None, netuid=None, shutdown_dict=None, weight_request_queue=None):
+                 netuid=None, shutdown_dict=None, weight_request_queue=None):
         super().__init__(metagraph, running_unit_tests=running_unit_tests, is_backtesting=is_backtesting)
         self.position_manager = position_manager
         self.perf_ledger_manager = position_manager.perf_ledger_manager
@@ -28,8 +28,7 @@ class SubtensorWeightSetter(CacheController):
         self.transformed_list = []
         self.slack_notifier = slack_notifier
         
-        # Config and IPC setup
-        self.config = config
+        # IPC setup
         self.netuid = netuid
         self.shutdown_dict = shutdown_dict if shutdown_dict is not None else {}
         self.weight_request_queue = weight_request_queue
@@ -194,16 +193,9 @@ class SubtensorWeightSetter(CacheController):
             uids = [x[0] for x in transformed_list]
             weights = [x[1] for x in transformed_list]
             
-            # Create serializable wallet config
-            wallet_config = {
-                'name': self.config.wallet.name,
-                'hotkey': self.config.wallet.hotkey,
-                'path': self.config.wallet.path
-            }
-            
             # Send request (no response expected)
+            # MetagraphUpdater will use its own config to create wallet
             request = {
-                'wallet_config': wallet_config,
                 'netuid': self.netuid,
                 'uids': uids,
                 'weights': weights,
@@ -216,3 +208,4 @@ class SubtensorWeightSetter(CacheController):
             
         except Exception as e:
             bt.logging.error(f"Error sending weight request: {e}")
+            bt.logging.error(traceback.format_exc())

--- a/vali_objects/utils/subtensor_weight_setter.py
+++ b/vali_objects/utils/subtensor_weight_setter.py
@@ -17,100 +17,6 @@ from vali_objects.vali_dataclasses.perf_ledger import PerfLedger
 from shared_objects.subtensor_lock import get_subtensor_lock
 
 
-class WeightFailureTracker:
-    """Track weight setting failures and manage alerting logic"""
-    
-    def __init__(self):
-        self.consecutive_failures = 0
-        self.last_success_time = time.time()
-        self.last_alert_time = 0
-        self.failure_patterns = {}  # Track unknown error patterns
-        self.had_critical_failure = False
-        
-    def classify_failure(self, err_msg):
-        """Classify failure based on production patterns"""
-        error_lower = err_msg.lower()
-        
-        # BENIGN - Don't alert (expected behavior)
-        if any(phrase in error_lower for phrase in [
-            "no attempt made. perhaps it is too soon to commit weights",
-            "too soon to commit weights",
-            "too soon to commit"
-        ]):
-            return "benign"
-        
-        # CRITICAL - Alert immediately (known problematic patterns)
-        elif any(phrase in error_lower for phrase in [
-            "maximum recursion depth exceeded",
-            "invalid transaction",
-            "subtensor returned: invalid transaction"
-        ]):
-            return "critical"
-        
-        # UNKNOWN - Alert after pattern emerges
-        else:
-            return "unknown"
-    
-    def should_alert(self, failure_type, consecutive_count):
-        """Determine if we should send an alert"""
-        # Get current time once for consistency
-        current_time = time.time()
-        time_since_success = current_time - self.last_success_time
-        time_since_last_alert = current_time - self.last_alert_time
-        
-        # Alert if we haven't had a successful weight setting in 2 hours
-        # This is an absolute timeout that bypasses all other checks
-        if time_since_success > 7200:  # 2 hours
-            return True
-        
-        # Rate limiting check - but exempt critical errors and 1+ hour timeouts
-        if failure_type != "critical" and time_since_success <= 3600:
-            if time_since_last_alert < 600:
-                return False
-        
-        # Always alert for known critical errors (no rate limiting)
-        if failure_type == "critical":
-            return True
-        
-        # Alert if we haven't had a successful weight setting in 1 hour
-        # This check happens before benign check to catch prolonged benign failures
-        if time_since_success > 3600:
-            return True
-        
-        # Never alert for benign "too soon" errors (unless prolonged, caught above)
-        if failure_type == "benign":
-            return False
-        
-        # For unknown errors, alert after 2 consecutive failures
-        if failure_type == "unknown" and consecutive_count >= 2:
-            return True
-        
-        return False
-    
-    def track_failure(self, err_msg, failure_type):
-        """Track a failure"""
-        self.consecutive_failures += 1
-        
-        # Track if this was a critical failure
-        if failure_type == "critical":
-            self.had_critical_failure = True
-        
-        # Track unknown error patterns
-        if failure_type == "unknown":
-            pattern_key = err_msg[:50] if len(err_msg) > 50 else err_msg
-            self.failure_patterns[pattern_key] = self.failure_patterns.get(pattern_key, 0) + 1
-    
-    def track_success(self):
-        """Track a successful weight setting"""
-        # Check if we should send recovery alert
-        should_send_recovery = self.consecutive_failures > 0 and self.had_critical_failure
-        
-        # Reset tracking
-        self.consecutive_failures = 0
-        self.last_success_time = time.time()
-        self.had_critical_failure = False
-        
-        return should_send_recovery
 
 class SubtensorWeightSetter(CacheController):
     def __init__(self, metagraph, position_manager: PositionManager,
@@ -123,7 +29,6 @@ class SubtensorWeightSetter(CacheController):
         # Store weights for use in backtesting
         self.checkpoint_results = []
         self.transformed_list = []
-        self.weight_failure_tracker = WeightFailureTracker()
         self.slack_notifier = slack_notifier
         
         # Config and IPC setup
@@ -275,143 +180,11 @@ class SubtensorWeightSetter(CacheController):
 
         if success:
             bt.logging.success("Successfully set weights.")
-            
-            # Check if we should send recovery alert
-            if self.weight_failure_tracker.track_success() and self.slack_notifier:
-                self._send_recovery_alert(wallet)
         else:
-            # Classify the failure
-            failure_type = self.weight_failure_tracker.classify_failure(err_msg)
+            bt.logging.warning(f"Failed to set weights. Error message: {err_msg}")
             
-            # Log appropriately
-            if failure_type == "benign":
-                bt.logging.warning(f"Failed to set weights. Error message: {err_msg} (benign)")
-            else:
-                bt.logging.warning(f"Failed to set weights. Error message: {err_msg}")
-            
-            # Track the failure
-            self.weight_failure_tracker.track_failure(err_msg, failure_type)
-            
-            # Check if we should alert
-            if self.weight_failure_tracker.should_alert(failure_type, self.weight_failure_tracker.consecutive_failures):
-                self._send_weight_failure_alert(err_msg, failure_type, wallet)
-                self.weight_failure_tracker.last_alert_time = time.time()
+            # Note: Failure tracking now happens in MetagraphUpdater where actual weight setting occurs
     
-    def _send_weight_failure_alert(self, err_msg, failure_type, wallet):
-        """Send contextual Slack alert for weight setting failure"""
-        if not self.slack_notifier:
-            return
-        
-        # Get context information
-        hotkey = "unknown"
-        if wallet:
-            if hasattr(wallet, 'hotkey'):
-                if hasattr(wallet.hotkey, 'ss58_address'):
-                    hotkey = wallet.hotkey.ss58_address
-                else:
-                    bt.logging.warning("Wallet hotkey missing ss58_address attribute")
-            else:
-                bt.logging.warning("Wallet missing hotkey attribute")
-        else:
-            bt.logging.warning("Wallet parameter is None in weight failure alert")
-        
-        netuid = "unknown"
-        network = "unknown"
-        if self.config:
-            if hasattr(self.config, 'netuid'):
-                netuid = self.config.netuid
-            else:
-                bt.logging.warning("Config missing netuid attribute")
-                
-            if hasattr(self.config, 'subtensor'):
-                if hasattr(self.config.subtensor, 'network'):
-                    network = self.config.subtensor.network
-                else:
-                    bt.logging.warning("Config subtensor missing network attribute")
-            else:
-                bt.logging.warning("Config missing subtensor attribute")
-        else:
-            bt.logging.warning("Config is None - cannot determine network/netuid for alert")
-            
-        consecutive = self.weight_failure_tracker.consecutive_failures
-        
-        # Build alert message based on failure type
-        if "maximum recursion depth exceeded" in err_msg.lower():
-            message = f"🚨 CRITICAL: Weight setting recursion error\n" \
-                     f"Network: {network}\n" \
-                     f"Hotkey: {hotkey}\n" \
-                     f"Error: {err_msg}\n" \
-                     f"This indicates a serious code issue that needs immediate attention."
-        
-        elif "invalid transaction" in err_msg.lower():
-            message = f"🚨 CRITICAL: Subtensor rejected weight transaction\n" \
-                     f"Network: {network}\n" \
-                     f"Hotkey: {hotkey}\n" \
-                     f"Error: {err_msg}\n" \
-                     f"This may indicate wallet/balance issues or network problems."
-        
-        elif failure_type == "unknown":
-            message = f"❓ NEW PATTERN: Unknown weight setting failure\n" \
-                     f"Network: {network}\n" \
-                     f"Hotkey: {hotkey}\n" \
-                     f"Consecutive failures: {consecutive}\n" \
-                     f"Error: {err_msg}\n" \
-                     f"This is a new error pattern that needs investigation."
-        
-        else:
-            # Prolonged failure alert
-            time_since_success = time.time() - self.weight_failure_tracker.last_success_time
-            hours_since_success = time_since_success / 3600
-            
-            if hours_since_success >= 2:
-                urgency = "🚨 URGENT"
-                time_msg = f"No successful weight setting in {hours_since_success:.1f} hours"
-            else:
-                urgency = "⚠️ WARNING"
-                time_msg = f"No successful weight setting in {hours_since_success:.1f} hours"
-            
-            message = f"{urgency}: Weight setting issues detected\n" \
-                     f"Network: {network}\n" \
-                     f"Hotkey: {hotkey}\n" \
-                     f"{time_msg}\n" \
-                     f"Last error: {err_msg}"
-        
-        self.slack_notifier.send_message(message, level="error")
-    
-    def _send_recovery_alert(self, wallet):
-        """Send recovery alert after critical failures"""
-        if not self.slack_notifier:
-            return
-        
-        hotkey = "unknown"
-        if wallet:
-            if hasattr(wallet, 'hotkey'):
-                if hasattr(wallet.hotkey, 'ss58_address'):
-                    hotkey = wallet.hotkey.ss58_address
-                else:
-                    bt.logging.warning("Wallet hotkey missing ss58_address attribute in recovery alert")
-            else:
-                bt.logging.warning("Wallet missing hotkey attribute in recovery alert")
-        else:
-            bt.logging.warning("Wallet parameter is None in recovery alert")
-            
-        network = "unknown"
-        if self.config:
-            if hasattr(self.config, 'subtensor'):
-                if hasattr(self.config.subtensor, 'network'):
-                    network = self.config.subtensor.network
-                else:
-                    bt.logging.warning("Config subtensor missing network attribute in recovery alert")
-            else:
-                bt.logging.warning("Config missing subtensor attribute in recovery alert")
-        else:
-            bt.logging.warning("Config is None - cannot determine network for recovery alert")
-        
-        message = f"✅ Weight setting recovered after failures\n" \
-                 f"Network: {network}\n" \
-                 f"Hotkey: {hotkey}"
-        
-        self.slack_notifier.send_message(message, level="info")
     
     def run_update_loop(self):
         """

--- a/vali_objects/utils/subtensor_weight_setter.py
+++ b/vali_objects/utils/subtensor_weight_setter.py
@@ -18,7 +18,7 @@ from vali_objects.vali_dataclasses.perf_ledger import PerfLedger
 class SubtensorWeightSetter(CacheController):
     def __init__(self, metagraph, position_manager: PositionManager,
                  running_unit_tests=False, is_backtesting=False, slack_notifier=None,
-                 netuid=None, shutdown_dict=None, weight_request_queue=None):
+                 shutdown_dict=None, weight_request_queue=None):
         super().__init__(metagraph, running_unit_tests=running_unit_tests, is_backtesting=is_backtesting)
         self.position_manager = position_manager
         self.perf_ledger_manager = position_manager.perf_ledger_manager
@@ -29,7 +29,6 @@ class SubtensorWeightSetter(CacheController):
         self.slack_notifier = slack_notifier
         
         # IPC setup
-        self.netuid = netuid
         self.shutdown_dict = shutdown_dict if shutdown_dict is not None else {}
         self.weight_request_queue = weight_request_queue
 
@@ -194,9 +193,8 @@ class SubtensorWeightSetter(CacheController):
             weights = [x[1] for x in transformed_list]
             
             # Send request (no response expected)
-            # MetagraphUpdater will use its own config to create wallet
+            # MetagraphUpdater will use its own config for netuid and wallet
             request = {
-                'netuid': self.netuid,
                 'uids': uids,
                 'weights': weights,
                 'version_key': self.subnet_version,


### PR DESCRIPTION
1. Removes delay in weight setting for restored validators
2. Facilitates local development with per-trade-pair perf ledgers.

Negligible difference in validator "generate_request_core" speed. 

2025-08-11 20:53:56.188 |     SUCCESS      | RequestCoreManager completed a cycle in 39017 ms.
2025-08-11 20:58:43.024 |     SUCCESS      | RequestCoreManager completed a cycle in 35957 ms.
2025-08-11 21:00:11.260 |       INFO       | Running RequestCoreManager process.
2025-08-11 21:06:21.977 |     SUCCESS      | RequestCoreManager completed a cycle in 59798 ms.
2025-08-11 21:12:03.883 |     SUCCESS      | RequestCoreManager completed a cycle in 55735 ms.
(rt21) rt21@rt21-chk-validator:~/proprietary-trading-network$ tail /home/rt21/.pm2/logs/ptn-out.log -n 10000 | grep RequestCoreManager
