### PR TITLE
Add GET /miner-selections endpoint for retrieving all miner asset sel…

### DIFF
--- a/meta/meta.json
+++ b/meta/meta.json
@@ -1,3 +1,3 @@
 {
-  "subnet_version": "6.7.3"
+  "subnet_version": "6.7.4"
 }

--- a/ptn_api/rest_server.py
+++ b/ptn_api/rest_server.py
@@ -910,6 +910,34 @@ class PTNRestServer(APIKeyMixin):
                 bt.logging.error(f"Error processing asset selection: {e}")
                 return jsonify({'error': 'Internal server error processing asset selection'}), 500
 
+        @self.app.route("/miner-selections", methods=["GET"])
+        def get_miner_selections():
+            """Get all miner asset selection data."""
+            try:
+                # Check API key authentication
+                api_key = self._get_api_key_safe()
+
+                # Check if the API key is valid
+                if not self.is_valid_api_key(api_key):
+                    return jsonify({'error': 'Unauthorized access'}), 401
+
+                # Check if asset selection manager is available
+                if not self.asset_selection_manager:
+                    return jsonify({'error': 'Asset selection data not available'}), 503
+
+                # Get all miner selection data using the getter method
+                selections_data = self.asset_selection_manager.get_all_miner_selections()
+
+                return jsonify({
+                    'miner_selections': selections_data,
+                    'total_miners': len(selections_data),
+                    'timestamp': TimeUtil.now_in_millis()
+                })
+
+            except Exception as e:
+                bt.logging.error(f"Error retrieving miner selections: {e}")
+                return jsonify({'error': 'Internal server error retrieving miner selections'}), 500
+
     def _verify_coldkey_owns_hotkey(self, coldkey_ss58: str, hotkey_ss58: str) -> bool:
         """
         Verify that a coldkey owns the specified hotkey using subtensor.

--- a/vali_objects/utils/asset_selection_manager.py
+++ b/vali_objects/utils/asset_selection_manager.py
@@ -103,7 +103,7 @@ class AssetSelectionManager:
             bt.logging.warning("asset_selection_data appears empty or invalid")
             return
         try:
-            with self.asset_selections:
+            with self.asset_selection_lock:
                 synced_data = self._parse_asset_selections_dict(asset_selection_data)
                 self.asset_selections.clear()
                 self.asset_selections.update(synced_data)

--- a/vali_objects/utils/asset_selection_manager.py
+++ b/vali_objects/utils/asset_selection_manager.py
@@ -257,6 +257,30 @@ class AssetSelectionManager:
             import traceback
             bt.logging.error(traceback.format_exc())
 
+    def get_all_miner_selections(self) -> Dict[str, str]:
+        """
+        Get all miner asset selections as a dictionary.
+        
+        Returns:
+            Dict[str, str]: Dictionary mapping miner hotkeys to their asset class selections (as strings).
+                           Returns empty dict if no selections exist.
+        """
+        try:
+            # Only need lock for the copy operation to get a consistent snapshot
+            with self.asset_selection_lock:
+                # Convert the IPC dict to a regular dict
+                selections_copy = dict(self.asset_selections)
+            
+            # Lock not needed here - working with local copy
+            # Convert TradePairCategory objects to their string values
+            return {
+                hotkey: asset_class.value if hasattr(asset_class, 'value') else str(asset_class)
+                for hotkey, asset_class in selections_copy.items()
+            }
+        except Exception as e:
+            bt.logging.error(f"Error getting all miner selections: {e}")
+            return {}
+
     def receive_asset_selection_update(self, asset_selection_data: dict) -> bool:
         """
         Process an incoming AssetSelection synapse and update miner asset selection.


### PR DESCRIPTION
…ections

- Add new endpoint in rest_server.py with API key authentication
- Create get_all_miner_selections() method in AssetSelectionManager for safe IPC dict access
- Return miner selections with total count and timestamp
- Handle serialization of TradePairCategory enums to strings

🤖 Generated with [Claude Code](https://claude.ai/code)

## Taoshi Pull Request

### Description
[Provide a brief description of the changes introduced by this pull request.]

### Related Issues (JIRA)
[Reference any related issues or tasks that this pull request addresses or closes.]

### Checklist
- [ ] I have tested my changes on testnet.
- [ ] I have updated any necessary documentation.
- [ ] I have added unit tests for my changes (if applicable).
- [ ] If there are breaking changes for validators, I have (or will) notify the community in Discord of the release.

### Reviewer Instructions
[Provide any specific instructions or areas you would like the reviewer to focus on.]

### Definition of Done
- [ ] Code has been reviewed.
- [ ] All checks and tests pass.
- [ ] Documentation is up to date.
- [ ] Approved by at least one reviewer.

### Checklist (for the reviewer)
- [ ] Code follows project conventions.
- [ ] Code is well-documented.
- [ ] Changes are necessary and align with the project's goals.
- [ ] No breaking changes introduced.

### Optional: Deploy Notes
[Any instructions or notes related to deployment, if applicable.]

/cc @mention_reviewer
